### PR TITLE
refactor: More user-friendly features

### DIFF
--- a/src/main/scala/de/zalando/beard/renderer/ForContextFactory.scala
+++ b/src/main/scala/de/zalando/beard/renderer/ForContextFactory.scala
@@ -26,7 +26,8 @@ object ForContextFactory {
         newContext.updated(forIterationContext.templateIteratorIdentifier, newMap)
       }
       case other =>
-        throw new IllegalAccessException(s"We need a map here instead of ${other.getClass} with a value $other")
+        throw new IllegalAccessException(s"We need a map here instead of ${other.getClass} with a value $other " +
+          s"for iterator ${forIterationContext.templateIteratorIdentifier}:${forIterationContext.currentIndex}")
     }
   }
 }

--- a/src/test/scala/de/zalando/beard/renderer/BeardTemplateRendererSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/BeardTemplateRendererSpec.scala
@@ -172,12 +172,12 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
       }
 
       describe("users collection does not exist") {
-        it("should not render the template") {
+        it("should render else branch in the template") {
           val renderResult = StringWriterRenderResult()
-
-          intercept[IllegalStateException] {
-            renderer.render(template, renderResult, Map())
-          }
+          renderer.render(template, renderResult, Map.empty)
+          renderResult.result.toString should be("""
+                                                   |<div>No users</div>
+                                                   |""".stripMargin)
         }
       }
 


### PR DESCRIPTION
- Added possibility to use different types as an argument for {{if}}
  - null -> False
  - None -> False
  - empty String -> False
  - empty Collection -> False
  - empty Map -> False
- Added possiblity to render Options and Collections
  - None is rendered as an empty string, Some(content) unwrapped as a "content"
  - Collections are represented like a comma-separated list of string representations of the elements
  - null is rendered as an empty string
- Added possiblity to refer to the element of the collection using its index, like {{collection.5}}
