### PR TITLE
Remove whitespaces from grammar

### DIFF
--- a/src/main/antlr4/de/zalando/beard/BeardLexer.g4
+++ b/src/main/antlr4/de/zalando/beard/BeardLexer.g4
@@ -2,15 +2,13 @@ lexer grammar BeardLexer;
 
 LL : '{{' -> pushMode(INSIDE_INTERPOLATION);
 
-NL      : '\r'? '\n';
-
-WS      : [ \t];
-
-TEXT    : ~('{' | '}' | ' ' | '\t' | '\n' | '\r')+;
+NL : '\r'? '\n';
 
 CURLY_BRACKET : '{' | '}' ;
 
-COMMENT: '{{#' (LL| NL | WS | RR | TEXT)* '#}}' -> skip;
+COMMENT: '{{#' (LL| NL | ' ' | '\t' | RR | TEXT)* '#}}' -> skip;
+
+TEXT   :  ~[{}\r\n]+ ;
 
 mode INSIDE_INTERPOLATION;
 

--- a/src/main/antlr4/de/zalando/beard/BeardParser.g4
+++ b/src/main/antlr4/de/zalando/beard/BeardParser.g4
@@ -10,21 +10,19 @@ import de.zalando.beard.ast.*;
 
 beard
 locals [scala.collection.immutable.List<Statement> result]
-      : (extendsStatement NL?)? (NL* contentForStatement)* statement*
+      : statement*
       ;
 
 statement
 locals [Statement result]
          : structuredStatement
          | interpolation
-         | newLine
-         | white
          | text
          ;
 
 extendsStatement
 locals [ExtendsStatement result]
-    : LL EXTENDS attrValue RR
+    : LL EXTENDS attrValue RR NL?
     ;
 
 structuredStatement
@@ -33,85 +31,80 @@ structuredStatement
     | renderStatement
     | blockStatement
     | yieldStatement
+    | extendsStatement
+    | contentForStatement
     ;
 
 yieldStatement
 locals [YieldStatement result]
-    : NL WS* LL YIELD RR
-    | LL YIELD RR
+    : LL YIELD RR
     ;
 
 blockStatement
 locals [BlockStatement result]
-    : NL WS* blockInterpolation statement* NL WS* endBlockInterpolation
-    | blockInterpolation statement* endBlockInterpolation
+    :  blockInterpolation statement* endBlockInterpolation
     ;
 
 // {{ block header }}
 blockInterpolation
-    : LL BLOCK identifier RR
+    : LL BLOCK identifier RR NL?
     ;
 
 // {{/ block }}
 endBlockInterpolation
-    : LL SLASH BLOCK RR
+    : LL SLASH BLOCK RR NL?
     ;
 
 contentForStatement
 locals [ContentForStatement result]
-    : contentForInterpolation statement* NL WS* endContentForInterpolation NL?
-    | contentForInterpolation statement* endContentForInterpolation NL?
+    : contentForInterpolation statement* endContentForInterpolation
     ;
 
 // {{ contentFor header }}
 contentForInterpolation
-    : LL CONTENT_FOR identifier RR
+    : LL CONTENT_FOR identifier RR NL?
     ;
 
 // {{/ contentFor }}
 endContentForInterpolation
-    : LL SLASH CONTENT_FOR RR
+    : LL SLASH CONTENT_FOR RR NL?
     ;
 
 // {{render "the-template" name="Dan" email=the.email.variable}}
 renderStatement
 locals [RenderStatement result]
-    : NL WS* LL RENDER attrValue attribute* RR
-    | LL RENDER attrValue attribute* RR
+    : LL RENDER attrValue attribute* RR
     ;
 
 ifStatement
 locals [IfStatement result]
-    : NL? WS* ifInterpolation ifStatements+=statement+ NL? WS* elseInterpolation elseStatements+=statement+ NL? WS* endIfInterpolation NL? # IfElseStatement
-    | ifInterpolation ifStatements+=statement+ elseInterpolation elseStatements+=statement+ endIfInterpolation # IfElseStatement
-    | NL? WS* ifInterpolation statement+ NL? WS* endIfInterpolation NL? # IfOnlyStatement
+    : ifInterpolation ifStatements+=statement+ elseInterpolation elseStatements+=statement+ endIfInterpolation # IfElseStatement
     | ifInterpolation statement+ endIfInterpolation # IfOnlyStatement
     ;
 
 ifInterpolation
-    : LL IF compoundIdentifier RR
+    : LL IF compoundIdentifier RR NL?
     ;
 
 elseInterpolation
-    : LL ELSE RR
+    : LL ELSE RR NL?
     ;
 
 endIfInterpolation
-    : LL SLASH IF RR
+    : LL SLASH IF RR NL?
     ;
 
 forStatement
 locals [ForStatement result]
-    : NL WS* forInterpolation statement+ NL WS* endForInterpolation
-    | forInterpolation statement+ endForInterpolation
+    : forInterpolation statement+ endForInterpolation
     ;
 
 forInterpolation
-    : LL FOR iter+=identifier IN coll+=compoundIdentifier RR
+    : LL FOR iter+=identifier IN coll+=compoundIdentifier RR NL?
     ;
 
 endForInterpolation
-    : LL SLASH FOR RR
+    : LL SLASH FOR RR NL?
     ;
 
 interpolation
@@ -165,18 +158,9 @@ locals [Identifier result]
     : IDENTIFIER
     ;
 
-white
-locals [White result]
-    : WS+
-    ;
-
-newLine
-locals [NewLine result]
-    : NL+
-    ;
-
 text
 locals [Text result]
     : TEXT
     | CURLY_BRACKET
+    | NL
     ;

--- a/src/test/resources/extends-example/application.beard
+++ b/src/test/resources/extends-example/application.beard
@@ -6,4 +6,4 @@
             {{yield}}
         </div>
     </body>
-<html>
+</html>

--- a/src/test/resources/extends-example/head.beard
+++ b/src/test/resources/extends-example/head.beard
@@ -1,2 +1,1 @@
-
-    <div>This is the head</div>
+<div>This is the head</div>

--- a/src/test/resources/extends-example/header.beard
+++ b/src/test/resources/extends-example/header.beard
@@ -1,2 +1,1 @@
-
-        <div>This is the header</div>
+<div>This is the header</div>

--- a/src/test/resources/extends-example/index.beard
+++ b/src/test/resources/extends-example/index.beard
@@ -1,3 +1,2 @@
 {{extends "/extends-example/single-column.beard"}}
-
-                <div>Hello Index</div>
+<div>Hello Index</div>

--- a/src/test/resources/extends-example/single-column.beard
+++ b/src/test/resources/extends-example/single-column.beard
@@ -1,5 +1,4 @@
 {{extends "/extends-example/application.beard"}}
-
-            <div class="main-column">
+<div class="main-column">
                 {{yield}}
             </div>

--- a/src/test/resources/templates/if-empty-collection.beard
+++ b/src/test/resources/templates/if-empty-collection.beard
@@ -1,8 +1,8 @@
 {{if users }}
 <ul>
-  {{for user in users}}
+{{for user in users}}
   <li>{{user.name}}</li>
-  {{/for}}
+{{/for}}
 </ul>
 {{else}}
 <div>No users</div>

--- a/src/test/resources/templates/if-in-for-statement.beard
+++ b/src/test/resources/templates/if-in-for-statement.beard
@@ -2,5 +2,6 @@
 {{if user.isOdd}}
 {{user.name}} is odd
 {{else}}
-{{user.name}} is not odd{{/if}}
+{{user.name}} is not odd
+{{/if}}
 {{/for}}

--- a/src/test/resources/templates/if-nested-statements.beard
+++ b/src/test/resources/templates/if-nested-statements.beard
@@ -1,16 +1,17 @@
-some{{if user.isCool }}
+some
+{{if user.isCool }}
   {{user.name}} is cool
-  {{if user.isCool }}
+{{if user.isCool }}
     {{user.name}} is still cool
-  {{/if}}
-  some1
+{{/if}}
+    some1
 {{else}}
   some2
-  {{if user.isCool }}
+{{if user.isCool }}
     {{user.name}} is still cool
-  {{else}}
+{{else}}
     {{user.name}} is not cool
-  {{/if}}
+{{/if}}
   some3
 {{/if}}
 some4

--- a/src/test/resources/templates/layout-with-partial.beard
+++ b/src/test/resources/templates/layout-with-partial.beard
@@ -11,8 +11,8 @@
 <div class="container">
     {{render "/templates/_partial.beard" title=example.title presentations=example.presentations}}
 </div>
-    {{ render "/templates/_footer.beard" }}
-    {{ render "/templates/_footer.beard" }}
-    {{ render "/templates/_footer.beard" }}
+{{ render "/templates/_footer.beard" }}
+{{ render "/templates/_footer.beard" }}
+{{ render "/templates/_footer.beard" }}
 </body>
 </html>

--- a/src/test/scala/de/zalando/beard/parser/BeardLexerSpec.scala
+++ b/src/test/scala/de/zalando/beard/parser/BeardLexerSpec.scala
@@ -10,12 +10,11 @@ class BeardLexerSpec extends FunSpec with Matchers {
 
   describe("BeardLexer") {
     it("should parse the correct tokens") {
-      val stream = new ANTLRInputStream("more {{   hello   \n name='  He   llo  '}} { world   }")
+      val stream = new ANTLRInputStream("more {{   hello   \n name='  He   llo  '}}\n { world   }")
       val lexer = new BeardLexer(stream)
       val tokens = lexer.getAllTokens.map(token => (token.getText, lexer.getTokenNames.toList(token.getType))).toList
       val expected = List(
-        ("more", "TEXT"),
-        (" ", "WS"),
+        ("more ", "TEXT"),
         ("{{", "'{{'"),
         ("hello", "IDENTIFIER"),
         ("name", "IDENTIFIER"),
@@ -24,13 +23,10 @@ class BeardLexerSpec extends FunSpec with Matchers {
         ("  He   llo  ", "ATTR_TEXT"),
         ("'", "END_ATTR_VALUE"),
         ("}}", "'}}'"),
-        (" ", "WS"),
+        ("\n", "NL"),
+        (" ", "TEXT"),
         ("{", "CURLY_BRACKET"),
-        (" ", "WS"),
-        ("world", "TEXT"),
-        (" ", "WS"),
-        (" ", "WS"),
-        (" ", "WS"),
+        (" world   ", "TEXT"),
         ("}", "CURLY_BRACKET"))
       tokens shouldBe expected
     }

--- a/src/test/scala/de/zalando/beard/renderer/BeardTemplateRendererSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/BeardTemplateRendererSpec.scala
@@ -74,8 +74,8 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
 
         val renderResult = StringWriterRenderResult()
         renderer.render(template, renderResult, Map("users" -> Seq(Map("name" -> "Gigi"), Map("name" -> "Gicu"))))
-        renderResult.result.toString should be("<div>isFirst:true-isLast:false-Gigi-isOdd:false-isEven:true</div>" +
-          "<div>isFirst:false-isLast:true-Gicu-isOdd:true-isEven:false</div>")
+        renderResult.result.toString should be("<div>isFirst:true-isLast:false-Gigi-isOdd:false-isEven:true</div>\n" +
+          "<div>isFirst:false-isLast:true-Gicu-isOdd:true-isEven:false</div>\n")
       }
     }
 
@@ -89,7 +89,7 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
         it("should render the template") {
           val renderResult = StringWriterRenderResult()
           renderer.render(template, renderResult, context(true))
-          renderResult.result.toString should be("\nGigi is cool\n")
+          renderResult.result.toString should be("Gigi is cool\n")
         }
       }
 
@@ -112,7 +112,7 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
         it("should render the template") {
           val renderResult = StringWriterRenderResult()
           renderer.render(template, renderResult, context(true))
-          renderResult.result.toString should be("\nGigi is cool\n")
+          renderResult.result.toString should be("Gigi is cool\n")
         }
       }
 
@@ -120,7 +120,7 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
         it("should not render the template") {
           val renderResult = StringWriterRenderResult()
           renderer.render(template, renderResult, context(false))
-          renderResult.result.toString should be("\nGigi is not cool\n")
+          renderResult.result.toString should be("Gigi is not cool\n")
         }
       }
     }
@@ -134,7 +134,7 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
       it("should render the template") {
         val renderResult = StringWriterRenderResult()
         renderer.render(template, renderResult, context(true))
-        renderResult.result.toString should be("\nGigi is not odd\nGicu is odd\n")
+        renderResult.result.toString should be("Gigi is not odd\nGicu is odd\n")
       }
     }
 
@@ -144,14 +144,16 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
 
       val template = templateCompiler.compile(TemplateName("/templates/if-nested-statements.beard")).get
 
-      it("should render the template") {
+      it("should render the template xxx") {
         val renderResult = StringWriterRenderResult()
         renderer.render(template, renderResult, context(true))
+
         renderResult.result.toString should be("""some
                                                  |  Gigi is cool
                                                  |    Gigi is still cool
                                                  |    some1
-                                                 |some4""".stripMargin)
+                                                 |some4
+                                                 |""".stripMargin)
       }
     }
 
@@ -165,9 +167,7 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
         it("should render the template") {
           val renderResult = StringWriterRenderResult()
           renderer.render(template, renderResult, Map("users" -> Seq()))
-          renderResult.result.toString should be("""
-                                                   |<div>No users</div>
-                                                   |""".stripMargin)
+          renderResult.result.toString should be("<div>No users</div>\n".stripMargin)
         }
       }
 
@@ -175,9 +175,7 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
         it("should render else branch in the template") {
           val renderResult = StringWriterRenderResult()
           renderer.render(template, renderResult, Map.empty)
-          renderResult.result.toString should be("""
-                                                   |<div>No users</div>
-                                                   |""".stripMargin)
+          renderResult.result.toString should be("<div>No users</div>\n".stripMargin)
         }
       }
 
@@ -185,8 +183,7 @@ class BeardTemplateRendererSpec extends FunSpec with Matchers {
         it("should render the template") {
           val renderResult = StringWriterRenderResult()
           renderer.render(template, renderResult, context(true))
-          renderResult.result.toString should be("""
-                                                   |<ul>
+          renderResult.result.toString should be("""<ul>
                                                    |  <li>Gigi</li>
                                                    |  <li>Gicu</li>
                                                    |</ul>

--- a/src/test/scala/de/zalando/beard/renderer/CustomizableTemplateCompilerSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/CustomizableTemplateCompilerSpec.scala
@@ -80,7 +80,8 @@ class CustomizableTemplateCompilerSpec extends FunSpec with Matchers {
                     |            </div>
                     |        </div>
                     |    </body>
-                    |<html>""".stripMargin)),
+                    |</html>
+                    |""".stripMargin)),
             None, Seq(RenderStatement("/extends-example/head.beard"),
               RenderStatement("/extends-example/header.beard")))
         )


### PR DESCRIPTION
Handling whitespaces and newlines can be an fail prone taks.

In order to make the grammer simpler, generate less nodes and avoid
further problems, we are ignoring whitespaces.

Fixes #12
