### PR TITLE
Make compatible with Scala 2.12 (fixes #68)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import com.typesafe.sbt.SbtScalariform.{ScalariformKeys, scalariformSettingsWithIt}
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 import scalariform.formatter.preferences.{AlignSingleLineCaseStatements, DanglingCloseParenthesis, DoubleIndentClassDeclaration, Preserve, PreserveSpaceBeforeArguments, SpacesAroundMultiImports}
 
@@ -7,12 +7,12 @@ organization  := "de.zalando"
 version       := "0.1.3-SNAPSHOT"
 licenses      += ("Apache-2.0", url("http://www.apache.org/licenses/"))
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 scalacOptions := Seq("-unchecked", "-feature", "-deprecation", "-encoding", "utf8")
 
 val antlrVersion = "4.5.2"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.10.5")
+crossScalaVersions := Seq(scalaVersion.value, "2.11.8")
 
 antlr4Settings
 
@@ -30,18 +30,17 @@ libraryDependencies ++= {
                                                                               exclude("org.antlr", "ST4")
                                                                               exclude("org.antlr", "antlr-runtime"),
     "org.scala-lang"               % "scala-reflect"                        % scalaVersion.value,
-    "org.scala-lang.modules"       % "scala-xml_2.11"                       % "1.0.5",
-    "org.monifu"                  %% "monifu"                               % "1.0",
+    "org.scala-lang.modules"      %% "scala-xml"                            % "1.0.6",
+    "io.monix"                    %% "monix"                                % "2.1.0",
     "org.slf4j"                    % "slf4j-api"                            % "1.7.7",
     "ch.qos.logback"               % "logback-classic"                      % "1.1.7",
-    "org.scalatest"               %% "scalatest"                            % "3.0.0-M15"      % "test",
-    "org.scalamock"               %% "scalamock-scalatest-support"          % "3.2.2"          % "test",
+    "org.scalatest"               %% "scalatest"                            % "3.0.1"          % "test",
     "com.mitchellbosecke"          % "pebble"                               % "1.6.0"          % "test",
     "org.freemarker"               % "freemarker"                           % "2.3.23"         % "test",
     "com.github.spullara.mustache.java"   % "compiler"                      % "0.9.1"          % "test",
     "com.github.jknack"            % "handlebars"                           % "2.2.2"          % "test",
     "de.neuland-bfi"               % "jade4j"                               % "0.4.0"          % "test",
-    "com.storm-enroute"           %% "scalameter"                           % "0.7"            % "test"
+    "com.storm-enroute"           %% "scalameter"                           % "0.8.2"          % "test"
   )
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.11
+sbt.version = 0.13.13

--- a/src/main/scala/de/zalando/beard/parser/BeardTemplateListener.scala
+++ b/src/main/scala/de/zalando/beard/parser/BeardTemplateListener.scala
@@ -4,7 +4,7 @@ import de.zalando.beard.BeardParser._
 import de.zalando.beard.BeardParserBaseListener
 import de.zalando.beard.ast._
 import scala.collection.immutable.Seq
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class BeardTemplateListener extends BeardParserBaseListener {
 
@@ -25,13 +25,13 @@ class BeardTemplateListener extends BeardParserBaseListener {
   }
 
   override def exitCompoundIdentifier(ctx: CompoundIdentifierContext) = {
-    val identifiers = ctx.IDENTIFIER().map(id => id.getText).toList
+    val identifiers = ctx.IDENTIFIER().asScala.map(id => id.getText).toList
 
     ctx.result = CompoundIdentifier(identifiers.head, identifiers.tail)
   }
 
   override def exitFilter(ctx: FilterContext) = {
-    val parameters = ctx.attribute().toList.map(_.result)
+    val parameters = ctx.attribute().asScala.toList.map(_.result)
     ctx.result = FilterNode(ctx.identifier().result, parameters)
   }
 
@@ -55,73 +55,73 @@ class BeardTemplateListener extends BeardParserBaseListener {
     ctx.result = ExtendsStatement(ctx.attrValue().result)
 
   override def exitRenderStatement(ctx: RenderStatementContext) =
-    ctx.result = RenderStatement(ctx.attrValue().result, ctx.attribute().map(_.result).toList)
+    ctx.result = RenderStatement(ctx.attrValue().result, ctx.attribute().asScala.map(_.result).toList)
 
   override def exitBlockStatement(ctx: BlockStatementContext) =
-    ctx.result = BlockStatement(ctx.blockInterpolation().identifier().result, ctx.statement().flatMap(_.result).toList)
+    ctx.result = BlockStatement(ctx.blockInterpolation().identifier().result, ctx.statement().asScala.flatMap(_.result).toList)
 
   override def exitContentForStatement(ctx: ContentForStatementContext) =
-    ctx.result = ContentForStatement(ctx.contentForInterpolation().identifier().result, ctx.statement().flatMap(_.result).toList)
+    ctx.result = ContentForStatement(ctx.contentForInterpolation().identifier().result, ctx.statement().asScala.flatMap(_.result).toList)
 
   override def exitIfOnlyStatement(ctx: IfOnlyStatementContext) = {
-    val startingSpaceStatements = ctx.startingSpace.toList.map(_.result)
-    val ifSpaceStatements = ctx.ifSpace.toList.map(_.result)
+    val startingSpaceStatements = ctx.startingSpace.asScala.toList.map(_.result)
+    val ifSpaceStatements = ctx.ifSpace.asScala.toList.map(_.result)
 
     val condition = ctx.ifInterpolation().compoundIdentifier().result
-    val statements: Seq[Statement] = ctx.statement().flatMap(st => st.result).toList
+    val statements: Seq[Statement] = ctx.statement().asScala.flatMap(st => st.result).toList
     ctx.result = startingSpaceStatements ++ Seq(IfStatement(condition, statements ++ ifSpaceStatements))
   }
 
   override def exitIfElseStatement(ctx: IfElseStatementContext) = {
-    val startingSpaceStatements = ctx.startingSpace.toList.map(_.result)
-    val ifSpaceStatements = ctx.ifSpace.toList.map(_.result)
-    val elseSpaceStatements = ctx.elseSpace.toList.map(_.result)
+    val startingSpaceStatements = ctx.startingSpace.asScala.toList.map(_.result)
+    val ifSpaceStatements = ctx.ifSpace.asScala.toList.map(_.result)
+    val elseSpaceStatements = ctx.elseSpace.asScala.toList.map(_.result)
 
     val condition = ctx.ifInterpolation().compoundIdentifier().result
-    val ifStatements = ctx.ifStatements.flatMap(st => st.result).toList
-    val elseStatements = ctx.elseStatements.flatMap(st => st.result).toList
+    val ifStatements = ctx.ifStatements.asScala.flatMap(st => st.result).toList
+    val elseStatements = ctx.elseStatements.asScala.flatMap(st => st.result).toList
     ctx.result = startingSpaceStatements ++ Seq(IfStatement(condition, ifStatements ++ ifSpaceStatements, elseStatements ++ elseSpaceStatements))
   }
 
   override def exitUnlessOnlyStatement(ctx: UnlessOnlyStatementContext) = {
-    val startingSpaceStatements = ctx.startingSpace.toList.map(_.result)
-    val unlessSpaceStatements = ctx.unlessSpace.toList.map(_.result)
+    val startingSpaceStatements = ctx.startingSpace.asScala.toList.map(_.result)
+    val unlessSpaceStatements = ctx.unlessSpace.asScala.toList.map(_.result)
 
     val condition = ctx.unlessInterpolation().compoundIdentifier().result
-    val statements: Seq[Statement] = ctx.statement().flatMap(_.result).toList
+    val statements: Seq[Statement] = ctx.statement().asScala.flatMap(_.result).toList
     ctx.result = startingSpaceStatements ++ Seq(UnlessStatement(condition, statements ++ unlessSpaceStatements))
   }
 
   override def exitUnlessElseStatement(ctx: UnlessElseStatementContext) = {
-    val startingSpaceStatements = ctx.startingSpace.toList.map(_.result)
-    val unlessSpaceStatements = ctx.unlessSpace.toList.map(_.result)
-    val elseSpaceStatements = ctx.elseSpace.toList.map(_.result)
+    val startingSpaceStatements = ctx.startingSpace.asScala.toList.map(_.result)
+    val unlessSpaceStatements = ctx.unlessSpace.asScala.toList.map(_.result)
+    val elseSpaceStatements = ctx.elseSpace.asScala.toList.map(_.result)
 
     val condition = ctx.unlessInterpolation().compoundIdentifier().result
-    val unlessStatements = ctx.unlessStatements.flatMap(_.result).toList
-    val elseStatements = ctx.elseStatements.flatMap(_.result).toList
+    val unlessStatements = ctx.unlessStatements.asScala.flatMap(_.result).toList
+    val elseStatements = ctx.elseStatements.asScala.flatMap(_.result).toList
     ctx.result = startingSpaceStatements ++ Seq(UnlessStatement(condition, unlessStatements ++ unlessSpaceStatements, elseStatements ++ elseSpaceStatements))
   }
 
   override def exitForStatement(ctx: ForStatementContext) = {
-    val statements: Seq[Statement] = ctx.statement().flatMap(st => st.result).toList
+    val statements: Seq[Statement] = ctx.statement().asScala.flatMap(st => st.result).toList
 
     val leadingSpaceStatements = Option(ctx.leadingSpace()).toSeq.map(_.result).toList
 
     ctx.result = leadingSpaceStatements ++
-      List(ForStatement(ctx.forInterpolation().iter.head.result, ctx.forInterpolation().index.headOption.map(_.result),
-        ctx.forInterpolation().coll.head.result, statements, leadingSpaceStatements.nonEmpty))
+      List(ForStatement(ctx.forInterpolation().iter.asScala.head.result, ctx.forInterpolation().index.asScala.headOption.map(_.result),
+        ctx.forInterpolation().coll.asScala.head.result, statements, leadingSpaceStatements.nonEmpty))
   }
 
   override def exitAttrInterpolation(ctx: AttrInterpolationContext) = {
-    val attributes = ctx.attribute().map(a => a.result).toList
+    val attributes = ctx.attribute().asScala.map(a => a.result).toList
 
     ctx.result =
       AttrInterpolation(ctx.identifier().result, attributes)
   }
 
   override def exitIdInterpolation(ctx: IdInterpolationContext) = {
-    val filters = ctx.filter().toList.map(_.result)
+    val filters = ctx.filter().asScala.toList.map(_.result)
     ctx.result = IdInterpolation(ctx.compoundIdentifier().result, filters)
   }
 
@@ -148,13 +148,13 @@ class BeardTemplateListener extends BeardParserBaseListener {
   }
 
   override def exitBeard(ctx: BeardContext) = {
-    val statements = ctx.statement().flatMap(_.result).toList
+    val statements = ctx.statement().asScala.flatMap(_.result).toList
     val renderStatements = statements.collect {
       case renderStatement: RenderStatement => renderStatement
     }
     ctx.result = statements
     val extended = Option(ctx.extendsStatement()).map(_.result)
-    val contentForStatements = ctx.contentForStatement().map(_.result).toList
+    val contentForStatements = ctx.contentForStatement().asScala.map(_.result).toList
     result = BeardTemplate(statements, extended, renderStatements, contentForStatements)
   }
 }

--- a/src/main/scala/de/zalando/beard/renderer/RenderResult.scala
+++ b/src/main/scala/de/zalando/beard/renderer/RenderResult.scala
@@ -1,8 +1,8 @@
 package de.zalando.beard.renderer
 
 import java.io.StringWriter
-import monifu.reactive.subjects.ReplaySubject
-import monifu.reactive.Observable
+import monix.reactive.subjects.ReplaySubject
+import monix.reactive.Observable
 
 /**
  * @author dpersa
@@ -32,7 +32,7 @@ case class MonifuRenderResult()
   val subject = ReplaySubject[Observable[String]]()
 
   override def write(renderedChunk: String): Unit = {
-    subject.onNext(Observable.from(renderedChunk))
+    subject.onNext(Observable.pure(renderedChunk))
   }
 
   override def complete(): Unit = subject.onComplete()

--- a/src/test/scala/de/zalando/beard/parser/BeardLexerSpec.scala
+++ b/src/test/scala/de/zalando/beard/parser/BeardLexerSpec.scala
@@ -3,7 +3,7 @@ package de.zalando.beard.parser
 import org.antlr.v4.runtime.ANTLRInputStream
 import org.scalatest.{FunSpec, Matchers}
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class BeardLexerSpec extends FunSpec with Matchers {
 
@@ -11,7 +11,7 @@ class BeardLexerSpec extends FunSpec with Matchers {
     it("should parse the correct tokens") {
       val stream = new ANTLRInputStream("more {{   hello   \n name='  He   llo  '}} { world   } {{ val | filter }}")
       val lexer = new CustomBeardLexer(stream)
-      val tokens = lexer.getAllTokens.map(token => (token.getText, lexer.getTokenNames.toList(token.getType))).toList
+      val tokens = lexer.getAllTokens.asScala.map(token => (token.getText, lexer.getTokenNames.toList(token.getType))).toList
       val expected = List(
         ("more", "TEXT"),
         (" ", "WS"),

--- a/src/test/scala/de/zalando/beard/performance/BeardSecondBenchmark.scala
+++ b/src/test/scala/de/zalando/beard/performance/BeardSecondBenchmark.scala
@@ -1,10 +1,8 @@
 package de.zalando.beard.performance
 
-import java.util.{Locale, ResourceBundle}
-
 import de.zalando.beard.parser.BeardTemplateParser
 import de.zalando.beard.renderer._
-import monifu.concurrent.Implicits.globalScheduler
+import monix.execution.Scheduler.Implicits.global
 import org.scalameter.api._
 
 import scala.io.Source

--- a/src/test/scala/de/zalando/beard/performance/FreemarkerBenchmark.scala
+++ b/src/test/scala/de/zalando/beard/performance/FreemarkerBenchmark.scala
@@ -14,7 +14,7 @@ import scala.collection.JavaConverters._
  */
 object FreemarkerBenchmark extends Bench.LocalTime {
   val config = new Configuration(Configuration.VERSION_2_3_23)
-  val loader = new ClassTemplateLoader()
+  val loader = new ClassTemplateLoader(getClass, "/")
 
   config.setTemplateLoader(loader)
 


### PR DESCRIPTION
- update sbt to 0.13.13
- updated dependencies to support Scala 2.12
- drop Scala 2.10 support (would probably need a separate branch due to Scala XML)
- switch from Monifu to Monix
- fix some deprecation warnings (java conversions, freemarker)
- clean up some unused imports

Don't merge if you want to keep the Scala 2.10 support. - Not sure how to easily keep it, though. - I think it might be broken already due to importing the XML module from Scala 2.11 brutally. Not sure what this does to binary compatibility.