### PR TITLE
"Template not found" exception

### DIFF
--- a/src/main/scala/de/zalando/beard/renderer/DefaultTemplateCompiler.scala
+++ b/src/main/scala/de/zalando/beard/renderer/DefaultTemplateCompiler.scala
@@ -36,7 +36,7 @@ class CustomizableTemplateCompiler(
           case None =>
             val templateFileSource = templateLoader.load(templateName) match {
               case Some(content) => content
-              case _             => throw new IllegalStateException(s"Could not find template with name ${templateName}")
+              case _             => throw templateLoader.failure(templateName)
             }
 
             val rawTemplate = templateParser.parse(templateFileSource.mkString)

--- a/src/main/scala/de/zalando/beard/renderer/TemplateLoader.scala
+++ b/src/main/scala/de/zalando/beard/renderer/TemplateLoader.scala
@@ -3,6 +3,7 @@ package de.zalando.beard.renderer
 import java.io.File
 import org.slf4j.LoggerFactory
 import scala.io.Source
+import scala.util.{Try, Success, Failure}
 
 /**
  * @author dpersa
@@ -49,10 +50,21 @@ class FileTemplateLoader(
 
   override def load(templateName: TemplateName) = {
 
-    val file = new File(s"$directoryPath/${templateName.name}$templateSuffix")
+    val path = buildPath(templateName)
 
-    Option(Source.fromFile(file))
+    Try { Source.fromFile(path) } match {
+      case Success(source) => Option(source)
+      case Failure(_)      => None
+    }
   }
+
+  override def failure(templateName: TemplateName) = {
+    val path = buildPath(templateName)
+    new TemplateNotFoundException(s"Expected to find template '${templateName.name}' in file '${path}', file not found")
+  }
+
+  def buildPath(templateName: TemplateName) =
+    s"$directoryPath/${templateName.name}$templateSuffix"
 }
 
 class TemplateNotFoundException(msg: String) extends Exception(msg) {}

--- a/src/test/scala/de/zalando/beard/renderer/ClasspathTemplateLoaderSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/ClasspathTemplateLoaderSpec.scala
@@ -15,6 +15,13 @@ class ClasspathTemplateLoaderSpec extends FunSpec with Matchers {
       val template = loader.load(TemplateName("/loader/dir/template.beard"))
       template.isDefined.should(be(true))
     }
+
+    describe("template doesn't exist") {
+      it("should not load anything") {
+        val template = loader.load(TemplateName("/does/not/exist"))
+        template.isDefined.should(be(false))
+      }
+    }
   }
 
   describe("loader with prefix and suffix") {

--- a/src/test/scala/de/zalando/beard/renderer/CustomizableTemplateCompilerSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/CustomizableTemplateCompilerSpec.scala
@@ -107,10 +107,13 @@ class CustomizableTemplateCompilerSpec extends FunSpec with Matchers {
     describe("if the template is not found") {
 
       it ("should return failure") {
-        compiler.compile(TemplateName("some-name")) match {
-          case Failure(ex) =>
-          case _           => fail
-        }
+        val exception =
+          compiler.compile(TemplateName("some-name")) match {
+            case Failure(ex) => ex
+            case _           => fail
+          }
+        exception shouldBe a[TemplateNotFoundException]
+        exception.getMessage should equal("Expected to find template 'some-name' in file 'some-name', file not found on classpath")
       }
     }
   }

--- a/src/test/scala/de/zalando/beard/renderer/CustomizableTemplateCompilerSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/CustomizableTemplateCompilerSpec.scala
@@ -1,6 +1,7 @@
 package de.zalando.beard.renderer
 
 import de.zalando.beard.ast._
+import de.zalando.beard.parser.BeardTemplateParser
 import org.scalatest.{FunSpec, Matchers}
 
 import scala.collection.immutable.{Map, Seq}
@@ -114,6 +115,25 @@ class CustomizableTemplateCompilerSpec extends FunSpec with Matchers {
           }
         exception shouldBe a[TemplateNotFoundException]
         exception.getMessage should equal("Expected to find template 'some-name' in file 'some-name', file not found on classpath")
+      }
+    }
+  }
+
+  describe("with FileTemplateLoader") {
+    val compiler = new CustomizableTemplateCompiler(
+      new FileTemplateLoader(""),
+      new BeardTemplateCache(),
+      new BeardTemplateParser())
+
+    describe("if the template is not found") {
+      it ("should return failure") {
+        val exception =
+          compiler.compile(TemplateName("some-name")) match {
+            case Failure(ex) => ex
+            case _           => fail
+          }
+        exception shouldBe a[TemplateNotFoundException]
+        exception.getMessage should equal("Expected to find template 'some-name' in file '/some-name', file not found")
       }
     }
   }

--- a/src/test/scala/de/zalando/beard/renderer/FileTemplateLoaderSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/FileTemplateLoaderSpec.scala
@@ -1,0 +1,37 @@
+package de.zalando.beard.renderer
+
+import org.scalatest.{Matchers, FunSpec}
+
+/**
+ * @author dpersa
+ */
+class FileTemplateLoaderSpec extends FunSpec with Matchers {
+
+  describe("simple loader") {
+
+    val loader = new FileTemplateLoader(".")
+
+    it("should load the template") {
+      val template = loader.load(TemplateName("src/test/resources/loader/dir/template.beard"))
+      template.isDefined.should(be(true))
+    }
+
+    describe("template doesn't exist") {
+      it("should not load anything") {
+        val template = loader.load(TemplateName("/does/not/exist"))
+        template.isDefined.should(be(false))
+      }
+    }
+  }
+
+  describe("loader with suffix") {
+
+    val loader = new FileTemplateLoader(directoryPath = ".", templateSuffix = ".beard")
+
+    it("should load the template") {
+      val template = loader.load(TemplateName("src/test/resources/loader/dir/template"))
+      template.isDefined.should(be(true))
+    }
+  }
+}
+


### PR DESCRIPTION
#23 doesn't say much concerning where the desired "meaningful errors" are missing, so I built a small test project and started exploring error scenarios. The first one I encountered was when loading a template which does not exist. Currently error type as well as location of it's origin and meaningfulness of it's message differ depending on the `TemplateLoader` used:

* with `ClasspathTemplateLoader` exception `java.lang.IllegalStateException: Could not find template with name TemplateName(doesnotexist)` is thrown by template *compiler*
* with `FileTemplateLoader` exception `java.io.FileNotFoundException: ./filetemplates/doesnotexist.beard (No such file or directory)` is thrown in the *loader*

I propose changes in order to unify behaviour in both cases: `TemplateNotFoundException` will be thrown with a human-readable message.