### PR TITLE
Refactor error handling during template loading

### DIFF
--- a/src/main/scala/de/zalando/beard/renderer/DefaultTemplateCompiler.scala
+++ b/src/main/scala/de/zalando/beard/renderer/DefaultTemplateCompiler.scala
@@ -34,10 +34,8 @@ class CustomizableTemplateCompiler(
         templateCache.get(templateName) match {
           case Some(template) => template
           case None =>
-            val template = templateLoader.load(templateName) match {
-              case Success(content)   => content
-              case Failure(exception) => throw exception
-            }
+            // ! throws error prepared by template loader if loading failed
+            val template = templateLoader.load(templateName).get
 
             val rawTemplate = templateParser.parse(template)
             templateCache.add(templateName, rawTemplate)

--- a/src/main/scala/de/zalando/beard/renderer/DefaultTemplateCompiler.scala
+++ b/src/main/scala/de/zalando/beard/renderer/DefaultTemplateCompiler.scala
@@ -4,7 +4,7 @@ import de.zalando.beard.ast._
 import de.zalando.beard.parser.BeardTemplateParser
 import scala.annotation.tailrec
 import scala.collection.immutable.Seq
-import scala.util.{Success, Try}
+import scala.util.{Success, Failure, Try}
 
 /**
  * @author dpersa
@@ -34,12 +34,12 @@ class CustomizableTemplateCompiler(
         templateCache.get(templateName) match {
           case Some(template) => template
           case None =>
-            val templateFileSource = templateLoader.load(templateName) match {
-              case Some(content) => content
-              case _             => throw templateLoader.failure(templateName)
+            val template = templateLoader.load(templateName) match {
+              case Success(content)   => content
+              case Failure(exception) => throw exception
             }
 
-            val rawTemplate = templateParser.parse(templateFileSource.mkString)
+            val rawTemplate = templateParser.parse(template)
             templateCache.add(templateName, rawTemplate)
             // TODO maybe do this in parallel
             compileRenderedTemplates(rawTemplate.renderStatements)

--- a/src/main/scala/de/zalando/beard/renderer/TemplateLoader.scala
+++ b/src/main/scala/de/zalando/beard/renderer/TemplateLoader.scala
@@ -49,13 +49,8 @@ class FileTemplateLoader(
 ) extends TemplateLoader {
 
   override def load(templateName: TemplateName) = {
-
     val path = buildPath(templateName)
-
-    Try { Source.fromFile(path) } match {
-      case Success(source) => Option(source)
-      case Failure(_)      => None
-    }
+    Try(Source.fromFile(path)).toOption
   }
 
   override def failure(templateName: TemplateName) = {

--- a/src/main/scala/de/zalando/beard/renderer/TemplateLoader.scala
+++ b/src/main/scala/de/zalando/beard/renderer/TemplateLoader.scala
@@ -1,6 +1,6 @@
 package de.zalando.beard.renderer
 
-import java.io.File
+import java.io.{File, FileNotFoundException}
 import org.slf4j.LoggerFactory
 import scala.io.Source
 import scala.util.{Try, Success, Failure}
@@ -10,11 +10,7 @@ import scala.util.{Try, Success, Failure}
  */
 trait TemplateLoader {
 
-  def load(templateName: TemplateName): Option[Source]
-
-  def failure(templateName: TemplateName) = {
-    new TemplateNotFoundException(s"Could not find template with name '${templateName.name}'")
-  }
+  def load(templateName: TemplateName): Try[String]
 }
 
 class ClasspathTemplateLoader(
@@ -24,23 +20,18 @@ class ClasspathTemplateLoader(
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   override def load(templateName: TemplateName) = {
-    val path = buildPath(templateName)
-    val resource = Option(getClass.getResourceAsStream(path))
+    val path = s"${templatePrefix}${templateName.name}$templateSuffix"
 
     logger.debug(s"Looking for template with path: $path")
 
-    resource.flatMap { res =>
-      Option(Source.fromInputStream(res))
+    val source = Option(getClass.getResourceAsStream(path))
+      .flatMap(stream => Option(Source.fromInputStream(stream)))
+      .flatMap(source => Option(source.mkString))
+    source match {
+      case Some(source) => new Success(source)
+      case None         => new Failure(new TemplateLoadException(s"Expected to find template '${templateName.name}' in file '${path}', file not found on classpath"))
     }
   }
-
-  override def failure(templateName: TemplateName) = {
-    val path = buildPath(templateName)
-    new TemplateNotFoundException(s"Expected to find template '${templateName.name}' in file '${path}', file not found on classpath")
-  }
-
-  def buildPath(templateName: TemplateName) =
-    s"${templatePrefix}${templateName.name}$templateSuffix"
 }
 
 class FileTemplateLoader(
@@ -49,17 +40,16 @@ class FileTemplateLoader(
 ) extends TemplateLoader {
 
   override def load(templateName: TemplateName) = {
-    val path = buildPath(templateName)
-    Try(Source.fromFile(path)).toOption
+    val path = s"$directoryPath/${templateName.name}$templateSuffix"
+    Try {
+      try {
+        Source.fromFile(path).mkString
+      } catch {
+        case e: FileNotFoundException =>
+          throw new TemplateLoadException(s"Expected to find template '${templateName.name}' in file '${path}', file not found")
+      }
+    }
   }
-
-  override def failure(templateName: TemplateName) = {
-    val path = buildPath(templateName)
-    new TemplateNotFoundException(s"Expected to find template '${templateName.name}' in file '${path}', file not found")
-  }
-
-  def buildPath(templateName: TemplateName) =
-    s"$directoryPath/${templateName.name}$templateSuffix"
 }
 
-class TemplateNotFoundException(msg: String) extends Exception(msg) {}
+class TemplateLoadException(msg: String) extends Exception(msg) {}

--- a/src/test/scala/de/zalando/beard/renderer/ClasspathTemplateLoaderSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/ClasspathTemplateLoaderSpec.scala
@@ -1,6 +1,7 @@
 package de.zalando.beard.renderer
 
 import org.scalatest.{Matchers, FunSpec}
+import scala.util.{Success, Failure, Try}
 
 /**
  * @author dpersa
@@ -13,13 +14,13 @@ class ClasspathTemplateLoaderSpec extends FunSpec with Matchers {
 
     it("should load the template") {
       val template = loader.load(TemplateName("/loader/dir/template.beard"))
-      template.isDefined.should(be(true))
+      template.isSuccess.should(be(true))
     }
 
     describe("template doesn't exist") {
       it("should not load anything") {
         val template = loader.load(TemplateName("/does/not/exist"))
-        template.isDefined.should(be(false))
+        template.isSuccess.should(be(false))
       }
     }
   }
@@ -30,7 +31,7 @@ class ClasspathTemplateLoaderSpec extends FunSpec with Matchers {
 
     it("should load the template") {
       val template = loader.load(TemplateName("dir/template"))
-      template.isDefined.should(be(true))
+      template.isSuccess.should(be(true))
     }
   }
 }

--- a/src/test/scala/de/zalando/beard/renderer/CustomizableTemplateCompilerSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/CustomizableTemplateCompilerSpec.scala
@@ -113,7 +113,7 @@ class CustomizableTemplateCompilerSpec extends FunSpec with Matchers {
             case Failure(ex) => ex
             case _           => fail
           }
-        exception shouldBe a[TemplateNotFoundException]
+        exception shouldBe a[TemplateLoadException]
         exception.getMessage should equal("Expected to find template 'some-name' in file 'some-name', file not found on classpath")
       }
     }
@@ -132,7 +132,7 @@ class CustomizableTemplateCompilerSpec extends FunSpec with Matchers {
             case Failure(ex) => ex
             case _           => fail
           }
-        exception shouldBe a[TemplateNotFoundException]
+        exception shouldBe a[TemplateLoadException]
         exception.getMessage should equal("Expected to find template 'some-name' in file '/some-name', file not found")
       }
     }

--- a/src/test/scala/de/zalando/beard/renderer/FileTemplateLoaderSpec.scala
+++ b/src/test/scala/de/zalando/beard/renderer/FileTemplateLoaderSpec.scala
@@ -13,13 +13,13 @@ class FileTemplateLoaderSpec extends FunSpec with Matchers {
 
     it("should load the template") {
       val template = loader.load(TemplateName("src/test/resources/loader/dir/template.beard"))
-      template.isDefined.should(be(true))
+      template.isSuccess.should(be(true))
     }
 
     describe("template doesn't exist") {
       it("should not load anything") {
         val template = loader.load(TemplateName("/does/not/exist"))
-        template.isDefined.should(be(false))
+        template.isSuccess.should(be(false))
       }
     }
   }
@@ -30,7 +30,7 @@ class FileTemplateLoaderSpec extends FunSpec with Matchers {
 
     it("should load the template") {
       val template = loader.load(TemplateName("src/test/resources/loader/dir/template"))
-      template.isDefined.should(be(true))
+      template.isSuccess.should(be(true))
     }
   }
 }


### PR DESCRIPTION
When opening #73 I should have mentioned that it was result of almost my first encounter with Scala ever and that it was meant rather as POC for comments (or refusal) than as a contribution ready to be merged. When I realized it was merged almost immediately and without objections, I was scared. This PR attempts to fix flaws of the first one:

1. the exception is created in `TemplateLoader.load`, because only there the exact root of the failure is known (return value had to be changed because of that)
2. unexpected exceptions should not be caught under the hood and masked with `TemplateLoadException`; such exceptions should be thrown on their own
3. code too verbose due to my little knowledge of Scala and it's standard library rewritten to a more concise form

(Related to #23 )