### PR TITLE
explicitly set build antlr version to match runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ antlr4GenListener in Antlr4 := true
 
 antlr4GenVisitor in Antlr4 := true
 
+antlr4Version in Antlr4 := antlrVersion
+
 antlr4Dependency in Antlr4 := "org.antlr" % "antlr4" % antlrVersion
 
 antlr4PackageName in Antlr4 := Some("de.zalando.beard")


### PR DESCRIPTION
to fix the warning

`ANTLR Tool version 4.7.2 used for code generation does not match the
current runtime version 4.8`